### PR TITLE
fix issue where standard comma in optiondisplayitem replacements confuses game code

### DIFF
--- a/TranslationTools.sln
+++ b/TranslationTools.sln
@@ -58,6 +58,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MergeIntoDump", "src\MergeI
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared.Plugin", "src\Shared.Plugin\Shared.Plugin.shproj", "{A1BE9306-265D-45F8-BC45-A505FC0E2150}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HS2_TextDump", "src\HS2_TextDump\HS2_TextDump.csproj", "{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Core_TextResourceHelper\Core_TextResourceHelper.projitems*{0c56dbc3-848c-42fd-b4f2-ab31863261f8}*SharedItemsImports = 4
@@ -110,6 +112,10 @@ Global
 		src\Core_TextResourceRedirector\Core_TextResourceRedirector.projitems*{e0b39dba-571c-4b01-8479-63b59aa86b88}*SharedItemsImports = 4
 		src\Shared\Shared.projitems*{e0b39dba-571c-4b01-8479-63b59aa86b88}*SharedItemsImports = 4
 		src\KK_Common_TextDump\KK_Common_TextDump.projitems*{e22f76cc-c761-43da-a2de-ab282c0846e1}*SharedItemsImports = 13
+		src\AI_Common_TextDump\AI_Common_TextDump.projitems*{ecd8601a-dfc8-4c19-86bc-3017dd3951f2}*SharedItemsImports = 4
+		src\AI_TextResourceHelper\AI_TextResourceHelper.projitems*{ecd8601a-dfc8-4c19-86bc-3017dd3951f2}*SharedItemsImports = 4
+		src\Core_TextDump\Core_TextDump.projitems*{ecd8601a-dfc8-4c19-86bc-3017dd3951f2}*SharedItemsImports = 4
+		src\Shared.Plugin\Shared.Plugin.projitems*{ecd8601a-dfc8-4c19-86bc-3017dd3951f2}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -156,6 +162,10 @@ Global
 		{C65AE0BF-9D71-4420-8FA0-81F77CE303A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C65AE0BF-9D71-4420-8FA0-81F77CE303A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C65AE0BF-9D71-4420-8FA0-81F77CE303A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -178,6 +188,7 @@ Global
 		{49D20240-7621-4D4E-871C-9DD569668C96} = {C09C475A-6755-4E09-8D60-36B8FA2ADE63}
 		{E22F76CC-C761-43DA-A2DE-AB282C0846E1} = {C09C475A-6755-4E09-8D60-36B8FA2ADE63}
 		{C65AE0BF-9D71-4420-8FA0-81F77CE303A5} = {AF74661D-12F5-440F-980A-11AC18974B48}
+		{ECD8601A-DFC8-4C19-86BC-3017DD3951F2} = {C09C475A-6755-4E09-8D60-36B8FA2ADE63}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D0F79985-4CB7-46CB-BEC2-FF89C476ED20}

--- a/src/AI_TextDump/AI_TextDump.csproj
+++ b/src/AI_TextDump/AI_TextDump.csproj
@@ -97,4 +97,8 @@
   <PropertyGroup>
     <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) AI_ONLY</PostBuildEvent>
   </PropertyGroup>
+  <PropertyGroup>
+    <PreBuildEvent>
+</PreBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/src/Core_TextResourceHelper/Core.TextResourceHelper.cs
+++ b/src/Core_TextResourceHelper/Core.TextResourceHelper.cs
@@ -17,6 +17,8 @@ namespace IllusionMods
         protected static readonly string SpecializedKeyDelimiter = ":";
         public readonly char[] WhitespaceCharacters = {' ', '\t'};
 
+        public const char OptionSafeComma = '\u201a';
+
         private TextAssetTableHelper _tableHelper;
 
         protected static ManualLogSource Logger =>
@@ -60,10 +62,15 @@ namespace IllusionMods
             return new TextAssetTableHelper(new[] {"\r\n", "\r", "\n"}, new[] {"\t"});
         }
 
+        protected virtual bool IsValidExcelRowTranslationKey(string key)
+        {
+            return key != "0";
+        }
         public virtual IEnumerable<string> GetExcelRowTranslationKeys(string assetName, List<string> row, int i)
         {
             if (row == null || row.Count <= i) yield break;
-            yield return row[i];
+            var key = row[i];
+            if (IsValidExcelRowTranslationKey(key)) yield return key;
         }
 
         public virtual bool IsOptionDisplayItemAsset(string assetName)
@@ -271,5 +278,15 @@ namespace IllusionMods
         }
 
 #endif
+        public string PrepareTranslationForReplacement(ExcelData asset, string translated)
+        {
+            if (IsOptionDisplayItemAsset(asset.name))
+            {
+                // use alternate comma because option display items are stored/split on comma
+                return translated.Replace(',', OptionSafeComma);
+            }
+
+            return translated;
+        }
     }
 }

--- a/src/Core_TextResourceRedirector/Core.ExcelDataHandler.cs
+++ b/src/Core_TextResourceRedirector/Core.ExcelDataHandler.cs
@@ -89,21 +89,28 @@ namespace IllusionMods
             var filter = columnsToTranslate.Count > 0;
 
 
+            var row = -1;
             foreach (var param in asset.list)
             {
+                row++;
+                if (param.list == null || param.list.Count < 1 || param.list[0] == "no") continue;
+
                 for (var i = 0; i < param.list.Count; i++)
                 {
                     if (filter && !columnsToTranslate.Contains(i)) continue;
 
                     foreach (var key in _textResourceHelper.GetExcelRowTranslationKeys(asset.name, param.list, i))
                     {
-
+                        Logger.DebugLogDebug($"Attempting excel replacement [{row}, {i}]: Searching for replacement key={key}");
                         if (string.IsNullOrEmpty(key)) continue;
                         if (cache.TryGetTranslation(key, true, out var translated))
                         {
                             result = true;
+                            translated = _textResourceHelper.PrepareTranslationForReplacement(asset, translated);
                             TranslationHelper.RegisterRedirectedResourceTextToPath(translated,
                                 calculatedModificationPath);
+                            Logger.DebugLogDebug($"Replacing [{row}, {i}]: key={key}: {param.list[i]} => {translated}");
+
                             param.list[i] = translated;
                             break;
                         }

--- a/src/Core_TextResourceRedirector/Core.TextResourceRedirector.cs
+++ b/src/Core_TextResourceRedirector/Core.TextResourceRedirector.cs
@@ -25,7 +25,7 @@ namespace IllusionMods
 
         public const string PluginName = "Text Resource Redirector";
         public const string GUID = "com.deathweasel.bepinex.textresourceredirector";
-        public const string Version = "1.2.3";
+        public const string Version = "1.2.4";
         internal new static ManualLogSource Logger;
 #if !HS
         internal ChaListDataHandler ChaListDataHandler;
@@ -130,14 +130,12 @@ namespace IllusionMods
                 {
                     AddTranslationDelegate = (AddTranslation) Delegate.CreateDelegate(
                         typeof(AddTranslation), defaultCache, method);
-                    Logger.LogDebug("InitXUA: Primary success");
                 }
                 catch (ArgumentException)
                 {
                     //  mono versions fallback to this
                     AddTranslationDelegate = (key, value, scope) =>
                         method.Invoke(defaultCache, new object[] {key, value, scope});
-                    Logger.LogDebug("InitXUA: Secondary success");
                 }
             }
 

--- a/src/HS2_TextDump/HS2.TextDump.cs
+++ b/src/HS2_TextDump/HS2.TextDump.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IllusionMods
+{
+    public partial class TextDump
+    {
+    }
+}

--- a/src/HS2_TextDump/HS2_TextDump.csproj
+++ b/src/HS2_TextDump/HS2_TextDump.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{ECD8601A-DFC8-4C19-86BC-3017DD3951F2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>IllusionMods</RootNamespace>
+    <AssemblyName>HS2_TextDump</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;HS2</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;HS2</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect.Assembly-CSharp.2017.6.30\lib\net35\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11\lib\net46\UnityEngine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\IllusionLibs.HoneySelect2.UnityEngine.CoreModule.2018.4.11\lib\net46\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="HS2.TextDump.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\Shared.Plugin\Shared.Plugin.projitems" Label="Shared" />
+  <Import Project="..\AI_Common_TextDump\AI_Common_TextDump.projitems" Label="Shared" />
+  <Import Project="..\AI_TextResourceHelper\AI_TextResourceHelper.projitems" Label="Shared" />
+  <Import Project="..\Core_TextDump\Core_TextDump.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>IF EXIST $(SolutionDir)PostBuild.bat CALL "$(SolutionDir)PostBuild.bat" $(TargetPath) HS2</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/src/HS2_TextDump/Properties/AssemblyInfo.cs
+++ b/src/HS2_TextDump/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HS2_TextDump")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HS2_TextDump")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ecd8601a-dfc8-4c19-86bc-3017dd3951f2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/HS2_TextDump/packages.config
+++ b/src/HS2_TextDump/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="IllusionLibs.HoneySelect.Assembly-CSharp" version="2017.6.30" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect.UnityEngine" version="5.3.5" targetFramework="net46" developmentDependency="true" />
+  <package id="IllusionLibs.HoneySelect2.UnityEngine.CoreModule" version="2018.4.11" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/src/KK_TextResourceHelper/KK_TextResourceHelper.cs
+++ b/src/KK_TextResourceHelper/KK_TextResourceHelper.cs
@@ -47,12 +47,13 @@ namespace IllusionMods
 
         public override IEnumerable<string> GetExcelRowTranslationKeys(string assetName, List<string> row, int i)
         {
-            if (row != null && row.Count > i && IsOptionDisplayItemAsset(assetName))
+            var isOptionDisplay = IsOptionDisplayItemAsset(assetName);
+            foreach (var key in base.GetExcelRowTranslationKeys(assetName, row, i))
             {
-                yield return $"OPTION[{row[0]}]:{row[i]}";
+                // specialized match much come first
+                if (isOptionDisplay) yield return $"OPTION[{row[0]}]:{key}";
+                yield return key;
             }
-
-            foreach (var key in base.GetExcelRowTranslationKeys(assetName, row, i)) yield return key;
         }
 
         public override string GetSpecializedKey(object obj, string defaultValue)


### PR DESCRIPTION
String from the optiondisplayitem tables are run  `,` joined to other data, then `,` split again later. Replacement strings with `,` in them need to be pre-processed to use an alternate character (using `\u201A` (SINGLE LOW-9 QUOTATION MARK, `‚`) which in most fonts seems to render exactly the same as a standard `,` but doesn't trip things up.